### PR TITLE
bugfix: Redirect if cannot get user from session

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { getUser } from "@/lib/session";
 import { BottomSection } from "./components/bottom-section";
 import { NavSection } from "./components/nav-section";
 import type { NavItem, NavSectionItems } from "types";
+import { Redirect } from "@/components/redirect";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -66,7 +67,7 @@ export default async function DashboardLayout({
 }: DashboardLayoutProps) {
   const user = await getUser();
   if (!user) {
-    throw new Error("User not found");
+    return <Redirect />;
   }
   return (
     <div className="min-h-screen flex">

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -46,19 +46,18 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   callbacks: {
-    async jwt({ token }) {
+    async session({ session, token }) {
       const dbUser = await prisma.user.findUnique({
         where: {
           id: token.sub,
         },
       });
+      
       if (!dbUser) {
-        log.warn("Auth", "Invalid token provided");
-        throw new Error("Invalid token");
+        log.warn("Auth", "User not found in database");
+        throw new Error("User not found");
       }
-      return token;
-    },
-    async session({ session, token }) {
+
       if (session.user && token.sub) {
         session.user.id = token.sub;
       }

--- a/components/redirect.tsx
+++ b/components/redirect.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { signOut } from 'next-auth/react';
+import { Icons } from './icons';
+
+export function Redirect() {
+  const router = useRouter();
+  
+  async function asyncSignOut() {
+    await signOut();
+  }
+
+  useEffect(() => {
+    asyncSignOut();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[]);
+
+  return <div className='w-screen h-screen flex justify-center items-center'>
+    <div className='text-2xl font-bold flex items-center gap-2 text-slate-900'>
+      <h1>Redirecting </h1>
+      <Icons.spinner width={24} height={24} strokeWidth={3} className='animate-spin' />
+      </div>
+  </div>;
+}


### PR DESCRIPTION
This pull request fixes a bug where an error is not catched if the user cannot be retrieved from his session. 

Example: An user has an active session in two browsers and delete his account in one while still logged on the other. Now he will be redirected automatically instead of having an error.