### PR TITLE
Fix: doc and sql query check of false positives

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ https://github.com/Lazzzer/structurizer/assets/43219964/41d7a85d-0f56-48ca-ae98-
 
 ## Object Storage
 
-L'application stocke ses documents pdf en utilisant le package `@aws-sdk/client-s3`. N'import quel Object Storage compatible s3 devrait fonctionner.
+L'application stocke ses documents pdf en utilisant le package `@aws-sdk/client-s3`. N'import quel Object Storage compatible S3 devrait fonctionner.
 
 Les Object Storages suivants ont été testés et sont fonctionnels avec l'application:
 - [x] [Amazon S3](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/getting-started-nodejs.html)
@@ -178,7 +178,7 @@ La base de données reste accessible localement avec les valeurs présentes dans
 
 L'application est maintenant disponible sur le même [lien](http://localhost:3001) que précédemment.
 
-### Arrêt des images
+### Arrêt des containers
 
 ```bash
 docker compose down

--- a/app/api/dashboard/ask/route.ts
+++ b/app/api/dashboard/ask/route.ts
@@ -54,7 +54,6 @@ export async function POST(req: NextRequest) {
   try {
     query = mitigateVulnerabilities(JSON.parse(json.output).sqlQuery, user.id);
     result = stringifyWithBigInt(await prisma.$queryRawUnsafe(query));
-    log.debug("Ask", req.method, "SQL Query: ", query);
     log.debug("Ask", req.method, "SQL Result: ", result);
   } catch (e) {
     log.warn("Ask", req.method, "Failed to execute SQL query");
@@ -100,9 +99,10 @@ function mitigateVulnerabilities(query: string, id: string) {
   if (query === "") {
     return query;
   }
+  log.debug("Ask", "POST", "SQL Query: ", query);
 
   const lowerCaseQuery = query.toLowerCase();
-  const unauthorizedStatements = ["insert", "update", "delete"];
+  const unauthorizedStatements = ["insert ", "update ", "delete "];
 
   for (let statement of unauthorizedStatements) {
     if (lowerCaseQuery.includes(statement)) {


### PR DESCRIPTION
This pull request changes some part of the README and had a small improvement in the `mitigateVulnerabilities`. Now SQL queries using the `updatedAt` columns wont be falsy flagged. Of course, the mitigate is still VERY rudimentary.